### PR TITLE
Fix .txt files being parsed as JSON in convert_document

### DIFF
--- a/ontocast/agent/convert_document.py
+++ b/ontocast/agent/convert_document.py
@@ -153,7 +153,7 @@ def convert_document(state: AgentState, tools: ToolBox) -> AgentState:
         return blocked if blocked is not None else state
 
     if file_extension == ".txt":
-        text = json.loads(file_content.decode("utf-8"))
+        text = file_content.decode("utf-8")
         state.set_docling_doc(plain_text_to_docling_doc(text, filename))
         blocked = _fail_when_fixed_catalog_ontology_missing(state)
         return blocked if blocked is not None else state

--- a/test/test_convert_document_txt.py
+++ b/test/test_convert_document_txt.py
@@ -1,0 +1,22 @@
+"""convert_document handles .txt uploads as plain text (regression for #67)."""
+
+from types import SimpleNamespace
+
+from ontocast.agent.convert_document import convert_document
+from ontocast.onto.enum import Status
+from ontocast.onto.state import AgentState
+from ontocast.toolbox import ToolBox
+
+
+def test_convert_document_txt_is_plain_text_not_json() -> None:
+    # A plain-text .txt payload is not valid JSON; it must not be json.loads'd.
+    state = AgentState(
+        raw_input={"note.txt": b"Hello world. This is plain text, not JSON."}
+    )
+    tools = ToolBox.__new__(ToolBox)
+    tools.converter = SimpleNamespace(supported_extensions=())
+
+    result = convert_document(state, tools)
+
+    assert result.status == Status.SUCCESS
+    assert result.docling_doc is not None


### PR DESCRIPTION
The .txt branch in convert_document ran the decoded file content through json.loads, so any plain-text upload raised JSONDecodeError at the "Convert to Text" node. plain_text_to_docling_doc already expects a plain string, so decode the bytes directly instead of JSON-parsing them.

Adds a regression test feeding a non-JSON .txt payload.

Fixes #67